### PR TITLE
fix: 修复C2C情况下postFile出错的问题

### DIFF
--- a/src/openapi/v1/resource.ts
+++ b/src/openapi/v1/resource.ts
@@ -40,7 +40,7 @@ const apiMap = {
   groupMessageURI: '/v2/groups/:openID/messages/:messageID',
   groupFilesURI: '/v2/groups/:openID/files',
   c2cMessagesURI: '/v2/users/:openID/messages',
-  c2cMessageURI: '/v2/groups/:openID/messages/:messageID',
-  c2cFilesURI: '/v2/groups/:openID/files',
+  c2cMessageURI: '/v2/users/:openID/messages/:messageID',
+  c2cFilesURI: '/v2/users/:openID/files',
 };
 export const getURL = (endpoint: keyof typeof apiMap) => apiMap[endpoint];


### PR DESCRIPTION
https://bot.q.qq.com/wiki/develop/api-v2/server-inter/message/send-receive/rich-media.html#%E7%94%A8%E4%BA%8E%E5%8D%95%E8%81%8A

HTTP URL为`/v2/users/{openid}/files`

> 与[#1](https://github.com/feilongproject/QQNodeSDK/pull/1)一致，仅更改分支名