### PR TITLE
fix: 修复WebSocket不使用动态Token鉴权的问题

### DIFF
--- a/src/client/websocket/websocket.ts
+++ b/src/client/websocket/websocket.ts
@@ -162,7 +162,7 @@ export class Ws {
         const authOp = {
             op: OpCode.IDENTIFY, // 鉴权参数
             d: {
-                token: `Bot ${this.config.appID}.${this.config.token}`, // 根据配置转换token
+                token: this.config.secret ? `QQBot ${this.config.token}` : `Bot ${this.config.appID}.${this.config.token}`, // 根据配置转换token
                 intents: this.getValidIntents(), // todo 接受的类型
                 shard: this.checkShards(this.config.shards) || [0, 1], // 分片信息,给一个默认值
                 properties: {

--- a/src/openapi/v1/openapi.ts
+++ b/src/openapi/v1/openapi.ts
@@ -90,7 +90,7 @@ export class OpenAPI implements IOpenAPI {
     addUserAgent(options.headers);
 
     //是否使用固定token
-    if (token != '') {
+    if (!secret && token) {
       options.headers['Authorization'] = `Bot ${appID}.${token}`;
     } else {
       if (!this.tokenExpires || this.tokenExpires < Date.now()) {

--- a/src/types/websocket-types.ts
+++ b/src/types/websocket-types.ts
@@ -30,6 +30,7 @@ export interface EventTypes {
 export interface GetWsParam {
   appID: string;
   token: string;
+  secret?: string;
   sandbox?: boolean;
   shards?: Array<number>;
   intents?: Array<AvailableIntentsEventsEnum>;


### PR DESCRIPTION
> 还以为这个项目不维护了，所以当时看到有问题就没有发pr

#5 原来的逻辑里， 只对OpenAPI做了这个动态Token鉴权，而ws那边没有，导致使用后还是会报错。

这个PR给ws也加了鉴权，顺便优化了一下判断有没有token的逻辑（之前 `token != ''` 有点太简单粗暴了）